### PR TITLE
Don't delete soft links when -L not set

### DIFF
--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -125,7 +125,7 @@ function sync {
   # Order of includes/excludes/filters is EXTREMELY important
   echo "# Saving current state and backing up files (if needed)"
   echo "  | Root dir: $(pwd)"   
-  rsync -av --list-only --exclude "/$DOT_DIR" $RSYNC_OPTS $USER_RULES . | grep "^-\|^d|^l" \
+  rsync -av --list-only --exclude "/$DOT_DIR" $RSYNC_OPTS $USER_RULES . | grep "^-\|^d\|^l" \
       | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:->.*::" | sed "s:^/\.::" | sort > "$STATE_DIR/tree-current"
 
   # Prevent bringing back locally deleted files or removing new local files

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -126,7 +126,7 @@ function sync {
   echo "# Saving current state and backing up files (if needed)"
   echo "  | Root dir: $(pwd)"   
   rsync -av --list-only --exclude "/$DOT_DIR" $RSYNC_OPTS $USER_RULES . | grep "^-\|^d\|^l" \
-      | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:->.*::" | sed "s:^/\.::" | sort > "$STATE_DIR/tree-current"
+      | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s: ->.*::" | sed "s:^/\.::" | sort > "$STATE_DIR/tree-current"
 
   # Prevent bringing back locally deleted files or removing new local files
   cp -f "$STATE_DIR/added-prev" "$TMP_DIR/fetch-exclude"

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -125,8 +125,8 @@ function sync {
   # Order of includes/excludes/filters is EXTREMELY important
   echo "# Saving current state and backing up files (if needed)"
   echo "  | Root dir: $(pwd)"   
-  rsync -av --list-only --exclude "/$DOT_DIR" $RSYNC_OPTS $USER_RULES . | grep "^-\|^d" \
-      | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:^/\.::" | sort > "$STATE_DIR/tree-current"
+  rsync -av --list-only --exclude "/$DOT_DIR" $RSYNC_OPTS $USER_RULES . | grep "^-\|^d|^l" \
+      | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:->.*::" | sed "s:^/\.::" | sort > "$STATE_DIR/tree-current"
 
   # Prevent bringing back locally deleted files or removing new local files
   cp -f "$STATE_DIR/added-prev" "$TMP_DIR/fetch-exclude"


### PR DESCRIPTION
I've updated the lines which generate tree-current so that soft links make it through the grep and into fetch-exclude, even when -L is not set in the config file. Now, links are copied as links when -L is not set, and links are dereferenced when -L is set. The old behavior erased links when -L was not set.

I couldn't figure out how to run the spec code, so if anybody can provide some direction with that, or if somebody could run the specs that is probably an important step. Preliminary tests on my home machine were successful at providing expected behavior. 
