### PR TITLE
Fixed syncing of hidden files and directories.

### DIFF
--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -126,7 +126,7 @@ function sync {
   echo "# Saving current state and backing up files (if needed)"
   echo "  | Root dir: $(pwd)"   
   rsync -av --list-only --exclude "/$DOT_DIR" $RSYNC_OPTS $USER_RULES . | grep "^-\|^d" \
-      | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:^/\.::" | sort > "$STATE_DIR/tree-current"
+      | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:^/\.$::" | sort > "$STATE_DIR/tree-current"
 
   # Prevent bringing back locally deleted files or removing new local files
   cp -f "$STATE_DIR/added-prev" "$TMP_DIR/fetch-exclude"
@@ -165,7 +165,7 @@ function sync {
   echo
   echo "# Saving after-sync state and cleaning up"
   rsync -av --list-only --exclude "/$DOT_DIR" $USER_RULES . | grep "^-\|^d" \
-      | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:^/\.::" | sort > "$TMP_DIR/tree-after"
+      | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:^/\.$::" | sort > "$TMP_DIR/tree-after"
 
   # Save all newly created files for next run (to prevent deletion of them)
   # This includes files created by user in parallel to sync and files fetched from remote
@@ -341,7 +341,7 @@ function die {
 function list {
   echo -e "\x1b\x5b1;32mbitpocket\x1b\x5b0m will sync the following files:"
   rsync -av --list-only --exclude "/$DOT_DIR"  $USER_RULES . | grep "^-\|^d" \
-      | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:^/\.::" | sort 
+      | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:^/\.$::" | sort 
 }
 
 function usage {


### PR DESCRIPTION
All the hidden files and directories are currently being deleted. I think I found a bug causing this (if this is not the intended behaviour), as it seems to me the 'sed "s:^/.::"' command is there to remove the current directory from the list (".") and not all hidden files/dirs. Seems to work ok with the fix.
