### PR TITLE
Improve performance for large folders

### DIFF
--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -128,7 +128,7 @@ function pull() {
         -auzxi --delete --exclude "/$DOT_DIR" --exclude-from=- \
         $USER_RULES $REMOTE/ . \
   | while read line; do
-    if [[ "$line" =~ ^[ch\<\>]f|^\*deleting ]]; then
+    if [[ "$line" =~ ^[ch\<\>][fd]|^\*deleting ]]; then
       operation=${line%% *}
       filename=$(sed "s:^\S*\s*::" <<< "$line" | sed 's:\d96:\\\`:g')
       if [[ -f "$filename" ]]; then

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -205,16 +205,22 @@ function sync {
   # Prevent bringing back locally deleted files
   if [[ -s "$STATE_DIR/tree-prev" ]]; then
     comm -3 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" | sed -e "s:^[^/]*::" > "$TMP_DIR/local-add-del"
+  else
+    # In the case of a new sync, where no previous tree snapshot is available,
+    # assume all the files on the local side should be protected
+    cp "$STATE_DIR/tree-current" "$TMP_DIR/local-add-del"
   fi
 
   # Prevent deleting local files which were not deleted remotely
   # ie. Prevent deleting newly added local files
+  touch "$TMP_DIR/remote-del"
   if [[ -s "$STATE_DIR/tree-prev" ]]; then
     wait $remote_tree_pid
     comm -23 "$STATE_DIR/tree-prev" "$STATE_DIR/remote-tree-current" > "$TMP_DIR/remote-del"
   fi
 
-  pull && push
+  pull
+  push
 
   # Save after-sync state
   # Must be done with rsync itself (rather than find) to respect includes/excludes

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -192,7 +192,7 @@ function sync {
       filename=$(sed "s:^\S*\s*::" <<< "$line" | sed 's:\d96:\\\`:g')
       if [[ -f "$filename" ]]; then
         echo "  \`- $filename"
-        cp --parents -p "$filename" "$DOT_DIR"/backups/$TIMESTAMP || die "BACKUP"
+        cp --parents -p --reflink=auto "$filename" "$DOT_DIR"/backups/$TIMESTAMP || die "BACKUP"
       fi
     fi
   done

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -245,7 +245,7 @@ function sync {
   # and added via the pull()
   sort "$TMP_DIR/tree-after" \
   | comm -13 "$TMP_DIR/pull-delete" - \
-  | sed -e "s:^\s*::" \
+  | sed -e "s:^\s*::" -e "s:/\$::" \
   > "$STATE_DIR/tree-prev"
 
   rm "$TMP_DIR/tree-after"

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -110,10 +110,42 @@ function pull() {
   # Order of includes/excludes/filters is EXTREMELY important
   echo
   echo "# Pulling changes from server"
-  cat "$STATE_DIR/added-prev" \
-  | rsync -auzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" \
-      --exclude-from - $USER_RULES $REMOTE/ . \
+  echo "# >> Saving current state and backing up files (if needed)"
+
+  # Determine what will be fetched from server and make backup
+  # copies of any local files to be deleted or overwritten.
+  # Order of includes/excludes/filters is EXTREMELY important
+  cat "$STATE_DIR/added-prev" "$TMP_DIR/local-add-del" \
+  | rsync --dry-run \
+        -auzxi --delete --exclude "/$DOT_DIR" --exclude-from=- \
+        $USER_RULES $REMOTE/ . \
+  | while read line; do
+    if [[ "$line" =~ ^[ch\<\>]f|^\*deleting ]]; then
+      filename=$(sed "s:^\S*\s*::" <<< "$line" | sed 's:\d96:\\\`:g')
+      if [[ -f "$filename" ]]; then
+        [[ -d "$DOT_DIR"/backups/$TIMESTAMP ]] \
+          || mkdir -p "$DOT_DIR"/backups/$TIMESTAMP
+        cp --parents -p --reflink=auto "$filename" \
+          "$DOT_DIR"/backups/$TIMESTAMP || die "BACKUP"
+        echo "  B $filename" >&2
+      fi
+      # rsync does not support DELETE via --files-from, so delete inline here
+      # after the backup was made
+      if [[ "${line%% *}" == "*deleting" ]]; then
+        echo "  | *deleting $filename" >&2
+        [[ -d "$filename" ]] && rmdir "$filename" || rm "$filename"
+      else
+        # Sync the file. Use a NULL byte delimiter
+        printf '%s\0' "$filename"
+      fi
+    fi
+  done \
+  | rsync --files-from=- --from0 -auzxi $RSYNC_OPTS $USER_RULES \
+        $REMOTE/ . \
   | sed "s/^/  | /"  || die "PULL"
+
+  [[ -d "$DOT_DIR"/backups/$TIMESTAMP ]] \
+    && echo "  | Some files were backed up to $DOT_DIR/backups/$TIMESTAMP"
 }
 
 function push() {
@@ -149,24 +181,30 @@ function sync {
   # Save before-sync state
   # Must be done with rsync itself (rather than find) to respect includes/excludes
   # Order of includes/excludes/filters is EXTREMELY important
-  echo "# Saving current state and backing up files (if needed)"
+  echo "# Capturing current local and remote state"
   echo "  | Root dir: $(pwd)"
 
-  # Collect the current snapshot of the remote tree
+  # Collect the current snapshot of the remote tree, if a previous tree
+  # snapshot is available locally
   if [[ -s "$STATE_DIR/tree-prev" ]]; then
-    rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES $REMOTE/ | grep "^-\|^d" \
-      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" | sort > "$STATE_DIR/remote-tree-current" &
+    echo "  | Root dir: $REMOTE"
+    rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES $REMOTE/ \
+      | grep "^-\|^d" \
+      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" \
+      | sort > "$STATE_DIR/remote-tree-current" &
     local remote_tree_pid=$!
   fi
 
   # Collect the current snapshot of the local tree
-  rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES . | grep "^-\|^d" \
-      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" | sort > "$STATE_DIR/tree-current"
+  rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES . \
+      | grep "^-\|^d" \
+      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" \
+      | sort > "$STATE_DIR/tree-current" \
+      || die "SNAPSHOT"
 
   # Prevent bringing back locally deleted files
-  cp -f "$STATE_DIR/added-prev" "$TMP_DIR/fetch-exclude"
   if [[ -s "$STATE_DIR/tree-prev" ]]; then
-    comm -3 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" | sed -e "s:^[^/]*::" >> "$TMP_DIR/local-add-del"
+    comm -3 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" | sed -e "s:^[^/]*::" > "$TMP_DIR/local-add-del"
   fi
 
   # Prevent deleting local files which were not deleted remotely
@@ -176,32 +214,6 @@ function sync {
     comm -23 "$STATE_DIR/tree-prev" "$STATE_DIR/remote-tree-current" > "$TMP_DIR/remote-del"
   fi
 
-  # It is difficult to only create the backup directory if needed; instead
-  # we always create it, but remove it if it is empty afterwards.
-  mkdir -p $DOT_DIR/backups/$TIMESTAMP
-
-  # Determine what will be fetched from server and make backup
-  # copies of any local files to be deleted or overwritten.
-  # Order of includes/excludes/filters is EXTREMELY important
-  cat "$STATE_DIR/added-prev" "$TMP_DIR/local-add-del" \
-  | rsync --dry-run \
-        -auzxi --delete --exclude "/$DOT_DIR" --exclude-from - \
-        $USER_RULES $REMOTE/ . \
-  | while read line; do
-    if [[ "$line" =~ ^[ch\<\>]f|^\*deleting ]]; then
-      filename=$(sed "s:^\S*\s*::" <<< "$line" | sed 's:\d96:\\\`:g')
-      if [[ -f "$filename" ]]; then
-        echo "  \`- $filename"
-        cp --parents -p --reflink=auto "$filename" "$DOT_DIR"/backups/$TIMESTAMP || die "BACKUP"
-      fi
-    fi
-  done
-  if [ "$(ls -A "$DOT_DIR"/backups/$TIMESTAMP)" ]; then
-    echo "  | Some files were backed up to $DOT_DIR/backups/$TIMESTAMP"
-  else
-    rmdir "$DOT_DIR"/backups/$TIMESTAMP
-  fi
-
   pull && push
 
   # Save after-sync state
@@ -209,8 +221,10 @@ function sync {
   # Order of includes/excludes/filters is EXTREMELY important
   echo
   echo "# Saving after-sync state and cleaning up"
-  rsync -av --list-only --exclude "/$DOT_DIR" $USER_RULES . | grep "^-\|^d" \
-      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" | sort > "$TMP_DIR/tree-after"
+  rsync -av --list-only --exclude "/$DOT_DIR" $USER_RULES . \
+      | grep "^-\|^d" \
+      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" \
+      | sort > "$TMP_DIR/tree-after"
 
   # Save all newly created files for next run (to prevent deletion of them)
   # This includes files created by user in parallel to sync and files fetched from remote

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -141,9 +141,12 @@ function pull() {
       # rsync does not support DELETE via --files-from, so delete inline here
       # after the backup was made
       if [[ "$operation" == "*deleting" ]]; then
-        echo "  | *deleting   $filename" >&3
-        echo "/$filename" >&4
-        [[ -d "$filename" ]] && rmdir "$filename" || rm "$filename"
+        # Only delete locally if deleted remotely
+        if grep -q -x "/$filename" "$TMP_DIR/remote-del"; then
+          echo "  | *deleting   $filename" >&3
+          echo "/$filename" >&4
+          [[ -d "$filename" ]] && rmdir "$filename" || rm "$filename"
+        fi
         continue
       elif [[ "$operation" =~ \+\+\+\+$ ]]; then
         # Mark as added locally
@@ -176,6 +179,7 @@ function push() {
   # Order of includes/excludes/filters is EXTREMELY important
   echo
   echo "# Pushing changes to server"
+
   # Do not push back remotely deleted files
   cat "$TMP_DIR/remote-del" \
   | rsync -auzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" \

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -126,7 +126,7 @@ function pull() {
   cat "$TMP_DIR/local-add-del" \
   | rsync --dry-run \
         -auzxi --delete --exclude "/$DOT_DIR" --exclude-from=- \
-        $USER_RULES $REMOTE/ . \
+        $RSYNC_OPTS $USER_RULES $REMOTE/ . \
   | while read line; do
     filename=$(sed "s:^\S*\s*::" <<< "$line" | sed 's:\d96:\\\`:g')
     if [[ "$line" =~ ^[ch\<\>][fd]|^\*deleting ]]; then

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -112,37 +112,55 @@ function pull() {
   echo "# Pulling changes from server"
   echo "# >> Saving current state and backing up files (if needed)"
 
+  cp "$STATE_DIR/tree-current" "$TMP_DIR/tree-after"
+  touch "$TMP_DIR/pull-delete"
+
+  # Create a duplicate of STDOUT for logging of backed-up files, and use fd#4
+  # for logging of deleted files, which need to be sorted
+  exec 3>&1
+  exec 4> >(sort > "$TMP_DIR/pull-delete")
+
   # Determine what will be fetched from server and make backup
   # copies of any local files to be deleted or overwritten.
   # Order of includes/excludes/filters is EXTREMELY important
-  cat "$STATE_DIR/added-prev" "$TMP_DIR/local-add-del" \
+  cat "$TMP_DIR/local-add-del" \
   | rsync --dry-run \
         -auzxi --delete --exclude "/$DOT_DIR" --exclude-from=- \
         $USER_RULES $REMOTE/ . \
   | while read line; do
     if [[ "$line" =~ ^[ch\<\>]f|^\*deleting ]]; then
+      operation=${line%% *}
       filename=$(sed "s:^\S*\s*::" <<< "$line" | sed 's:\d96:\\\`:g')
       if [[ -f "$filename" ]]; then
         [[ -d "$DOT_DIR"/backups/$TIMESTAMP ]] \
           || mkdir -p "$DOT_DIR"/backups/$TIMESTAMP
         cp --parents -p --reflink=auto "$filename" \
           "$DOT_DIR"/backups/$TIMESTAMP || die "BACKUP"
-        echo "  B $filename" >&2
+        echo "  B $filename" >&3
       fi
       # rsync does not support DELETE via --files-from, so delete inline here
       # after the backup was made
-      if [[ "${line%% *}" == "*deleting" ]]; then
-        echo "  | *deleting $filename" >&2
+      if [[ "$operation" == "*deleting" ]]; then
+        echo "  | *deleting   $filename" >&3
+        echo "/$filename" >&4
         [[ -d "$filename" ]] && rmdir "$filename" || rm "$filename"
       else
         # Sync the file. Use a NULL byte delimiter
         printf '%s\0' "$filename"
+        if [[ "$operation" =~ \+\+\+\+$ ]]; then
+          # Mark as added locally
+          echo "/$filename" >> "$TMP_DIR/tree-after"
+        fi
       fi
     fi
   done \
   | rsync --files-from=- --from0 -auzxi $RSYNC_OPTS $USER_RULES \
         $REMOTE/ . \
-  | sed "s/^/  | /"  || die "PULL"
+  | sed "s/^/  | /" || die "PULL"
+
+  # Close extra file descriptors
+  exec 4>&-
+  exec 3>&-
 
   [[ -d "$DOT_DIR"/backups/$TIMESTAMP ]] \
     && echo "  | Some files were backed up to $DOT_DIR/backups/$TIMESTAMP"
@@ -176,7 +194,6 @@ function sync {
 
   # Check what has changed
   touch "$STATE_DIR/tree-prev"
-  touch "$STATE_DIR/added-prev"
 
   # Save before-sync state
   # Must be done with rsync itself (rather than find) to respect includes/excludes
@@ -223,21 +240,15 @@ function sync {
   push
 
   # Save after-sync state
-  # Must be done with rsync itself (rather than find) to respect includes/excludes
-  # Order of includes/excludes/filters is EXTREMELY important
-  echo
-  echo "# Saving after-sync state and cleaning up"
-  rsync -av --list-only --exclude "/$DOT_DIR" $USER_RULES . \
-      | grep "^-\|^d" \
-      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" \
-      | sort > "$TMP_DIR/tree-after"
 
-  # Save all newly created files for next run (to prevent deletion of them)
-  # This includes files created by user in parallel to sync and files fetched from remote
-  comm -23 "$TMP_DIR/tree-after" "$STATE_DIR/tree-current" >"$STATE_DIR/added-prev"
+  # Generate a incremental snapshot of the local tree including files deleted
+  # and added via the pull()
+  sort "$TMP_DIR/tree-after" \
+  | comm -13 "$TMP_DIR/pull-delete" - \
+  | sed -e "s:^\s*::" \
+  > "$STATE_DIR/tree-prev"
 
-  # Save new tree state for next run
-  mv "$TMP_DIR/tree-after" "$STATE_DIR/tree-prev"
+  rm "$TMP_DIR/tree-after"
 
   # Fire off slow sync stop notifier in background
   on_slow_sync_stop

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -217,7 +217,7 @@ function sync {
   comm -23 "$TMP_DIR/tree-after" "$STATE_DIR/tree-current" >"$STATE_DIR/added-prev"
 
   # Save new tree state for next run
-  cat "$STATE_DIR/tree-current" "$STATE_DIR/added-prev" >"$STATE_DIR/tree-prev"
+  mv "$TMP_DIR/tree-after" "$STATE_DIR/tree-prev"
 
   # Fire off slow sync stop notifier in background
   on_slow_sync_stop

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -104,6 +104,24 @@ function log {
   tail -f "$DOT_DIR/log"
 }
 
+function pull() {
+  # Actual fetch
+  # Pulling changes from server
+  # Order of includes/excludes/filters is EXTREMELY important
+  echo
+  echo "# Pulling changes from server"
+  rsync -auzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" --exclude-from "$TMP_DIR/fetch-exclude" $USER_RULES $REMOTE/ . | sed "s/^/  | /"  || die "PULL"
+}
+
+function push() {
+  # Actual push
+  # Send new and updated, remotely remove files deleted locally
+  # Order of includes/excludes/filters is EXTREMELY important
+  echo
+  echo "# Pushing changes to server"
+  rsync -auzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" $USER_RULES . $REMOTE/ | sed "s/^/  | /" || die "PUSH"
+}
+
 # Do the actual synchronization
 function sync {
   assert_dotdir
@@ -126,12 +144,24 @@ function sync {
   # Order of includes/excludes/filters is EXTREMELY important
   echo "# Saving current state and backing up files (if needed)"
   echo "  | Root dir: $(pwd)"
-  rsync -av --list-only --exclude "/$DOT_DIR" $RSYNC_OPTS $USER_RULES . | grep "^-\|^d" \
-      | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:^/\.::" | sort > "$STATE_DIR/tree-current"
 
-  # Prevent bringing back locally deleted files or removing new local files
+  # Collect the current snapshot of the local tree
+  rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES . | grep "^-\|^d" \
+      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" | sort > "$STATE_DIR/tree-current"
+
+  # Collect the current snapshot of the remote tree
+  rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES $REMOTE/ | grep "^-\|^d" \
+      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" | sort > "$STATE_DIR/remote-tree-current" &
+  local remote_tree_pid=$!
+
+  # Prevent bringing back locally deleted files
   cp -f "$STATE_DIR/added-prev" "$TMP_DIR/fetch-exclude"
-  sort "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" | uniq -u >> "$TMP_DIR/fetch-exclude"
+  comm -3 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" | sed -e "s:^[^/]*::" >> "$TMP_DIR/fetch-exclude"
+
+  # Prevent deleting local files which were not deleted remotely
+  # ie. Prevent deleting newly added local files
+  wait $remote_tree_pid
+  comm -23 "$STATE_DIR/tree-prev" "$STATE_DIR/remote-tree-current" >> "$TMP_DIR/fetch-exclude"
 
   # It is difficult to only create the backup directory if needed; instead
   # we always create it, but remove it if it is empty afterwards.
@@ -141,24 +171,24 @@ function sync {
   # copies of any local files to be deleted or overwritten.
   # Order of includes/excludes/filters is EXTREMELY important
   rsync --dry-run \
-        -auvzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" --exclude-from "$TMP_DIR/fetch-exclude" $USER_RULES $REMOTE/ . \
-      | grep "^[ch<>\.\*][f]\|\*deleting" | sed "s:^\S*\s*::" | sed 's:\d96:\\\`:g' | sed "s:\(.*\):if [ -f \"\1\" ]; then cp --parents \"\1\" $DOT_DIR/backups/$TIMESTAMP; fi:" | sh || die "BACKUP"
-  [ "$(ls -A $DOT_DIR/backups/$TIMESTAMP)" ] && echo "  | Some files were backed up to $DOT_DIR/backups/$TIMESTAMP"
-  [ "$(ls -A $DOT_DIR/backups/$TIMESTAMP)" ] || rmdir $DOT_DIR/backups/$TIMESTAMP
+        -auzxi --delete --exclude "/$DOT_DIR" --exclude-from "$TMP_DIR/fetch-exclude" \
+        $USER_RULES $REMOTE/ . \
+  | while read line; do
+    if [[ "$line" =~ ^[ch\<\>]f(cs|.s|c.)|^\*deleting ]]; then
+      filename=$(sed "s:^\S*\s*::" <<< "$line" | sed 's:\d96:\\\`:g')
+      if [ -f "$filename" ]; then
+        echo "  | $filename"
+        cp --parents "$filename" "$DOT_DIR"/backups/$TIMESTAMP || die "BACKUP"
+      fi
+    fi
+  done
+  if [ "$(ls -A "$DOT_DIR"/backups/$TIMESTAMP)" ]; then
+    echo "  | Some files were backed up to $DOT_DIR/backups/$TIMESTAMP"
+  else
+    rmdir "$DOT_DIR"/backups/$TIMESTAMP
+  fi
 
-  # Actual fetch
-  # Pulling changes from server
-  # Order of includes/excludes/filters is EXTREMELY important
-  echo
-  echo "# Pulling changes from server"
-  rsync -auvzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" --exclude-from "$TMP_DIR/fetch-exclude" $USER_RULES $REMOTE/ . | sed "s/^/  | /"  || die "PULL"
-
-  # Actual push
-  # Send new and updated, remotely remove files deleted locally
-  # Order of includes/excludes/filters is EXTREMELY important
-  echo
-  echo "# Pushing changes to server"
-  rsync -auvzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" $USER_RULES . $REMOTE/ | sed "s/^/  | /" || die "PUSH"
+  pull && push
 
   # Save after-sync state
   # Must be done with rsync itself (rather than find) to respect includes/excludes

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -128,9 +128,9 @@ function pull() {
         -auzxi --delete --exclude "/$DOT_DIR" --exclude-from=- \
         $USER_RULES $REMOTE/ . \
   | while read line; do
+    filename=$(sed "s:^\S*\s*::" <<< "$line" | sed 's:\d96:\\\`:g')
     if [[ "$line" =~ ^[ch\<\>][fd]|^\*deleting ]]; then
       operation=${line%% *}
-      filename=$(sed "s:^\S*\s*::" <<< "$line" | sed 's:\d96:\\\`:g')
       if [[ -f "$filename" ]]; then
         [[ -d "$DOT_DIR"/backups/$TIMESTAMP ]] \
           || mkdir -p "$DOT_DIR"/backups/$TIMESTAMP
@@ -144,15 +144,14 @@ function pull() {
         echo "  | *deleting   $filename" >&3
         echo "/$filename" >&4
         [[ -d "$filename" ]] && rmdir "$filename" || rm "$filename"
-      else
-        # Sync the file. Use a NULL byte delimiter
-        printf '%s\0' "$filename"
-        if [[ "$operation" =~ \+\+\+\+$ ]]; then
-          # Mark as added locally
-          echo "/$filename" >> "$TMP_DIR/tree-after"
-        fi
+        continue
+      elif [[ "$operation" =~ \+\+\+\+$ ]]; then
+        # Mark as added locally
+        echo "/$filename" >> "$TMP_DIR/tree-after"
       fi
     fi
+    # Sync the file. Use a NULL byte delimiter
+    printf '%s\0' "$filename"
   done \
   | rsync --files-from=- --from0 -auzxi $RSYNC_OPTS $USER_RULES \
         $REMOTE/ . \

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -205,7 +205,7 @@ function sync {
   if [[ -s "$STATE_DIR/tree-prev" ]]; then
     echo "  | Root dir: $REMOTE"
     rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES $REMOTE/ \
-      | grep "^-\|^d" \
+      | grep "^[dl-]" \
       | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" \
       | sort > "$STATE_DIR/remote-tree-current" &
     local remote_tree_pid=$!
@@ -213,7 +213,7 @@ function sync {
 
   # Collect the current snapshot of the local tree
   rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES . \
-      | grep "^-\|^d" \
+      | grep "^[dl-]" \
       | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" \
       | sort > "$STATE_DIR/tree-current" \
       || die "SNAPSHOT"

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -110,7 +110,10 @@ function pull() {
   # Order of includes/excludes/filters is EXTREMELY important
   echo
   echo "# Pulling changes from server"
-  rsync -auzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" --exclude-from "$TMP_DIR/fetch-exclude" $USER_RULES $REMOTE/ . | sed "s/^/  | /"  || die "PULL"
+  cat "$STATE_DIR/added-prev" \
+  | rsync -auzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" \
+      --exclude-from - $USER_RULES $REMOTE/ . \
+  | sed "s/^/  | /"  || die "PULL"
 }
 
 function push() {
@@ -119,7 +122,11 @@ function push() {
   # Order of includes/excludes/filters is EXTREMELY important
   echo
   echo "# Pushing changes to server"
-  rsync -auzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" $USER_RULES . $REMOTE/ | sed "s/^/  | /" || die "PUSH"
+  # Do not push back remotely deleted files
+  cat "$TMP_DIR/remote-del" \
+  | rsync -auzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" \
+      --exclude-from - $USER_RULES . $REMOTE/ \
+  | sed "s/^/  | /" || die "PUSH"
 }
 
 # Do the actual synchronization
@@ -145,23 +152,29 @@ function sync {
   echo "# Saving current state and backing up files (if needed)"
   echo "  | Root dir: $(pwd)"
 
+  # Collect the current snapshot of the remote tree
+  if [[ -s "$STATE_DIR/tree-prev" ]]; then
+    rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES $REMOTE/ | grep "^-\|^d" \
+      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" | sort > "$STATE_DIR/remote-tree-current" &
+    local remote_tree_pid=$!
+  fi
+
   # Collect the current snapshot of the local tree
   rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES . | grep "^-\|^d" \
       | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" | sort > "$STATE_DIR/tree-current"
 
-  # Collect the current snapshot of the remote tree
-  rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES $REMOTE/ | grep "^-\|^d" \
-      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" | sort > "$STATE_DIR/remote-tree-current" &
-  local remote_tree_pid=$!
-
   # Prevent bringing back locally deleted files
   cp -f "$STATE_DIR/added-prev" "$TMP_DIR/fetch-exclude"
-  comm -3 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" | sed -e "s:^[^/]*::" >> "$TMP_DIR/fetch-exclude"
+  if [[ -s "$STATE_DIR/tree-prev" ]]; then
+    comm -3 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" | sed -e "s:^[^/]*::" >> "$TMP_DIR/local-add-del"
+  fi
 
   # Prevent deleting local files which were not deleted remotely
   # ie. Prevent deleting newly added local files
-  wait $remote_tree_pid
-  comm -23 "$STATE_DIR/tree-prev" "$STATE_DIR/remote-tree-current" >> "$TMP_DIR/fetch-exclude"
+  if [[ -s "$STATE_DIR/tree-prev" ]]; then
+    wait $remote_tree_pid
+    comm -23 "$STATE_DIR/tree-prev" "$STATE_DIR/remote-tree-current" > "$TMP_DIR/remote-del"
+  fi
 
   # It is difficult to only create the backup directory if needed; instead
   # we always create it, but remove it if it is empty afterwards.
@@ -170,15 +183,16 @@ function sync {
   # Determine what will be fetched from server and make backup
   # copies of any local files to be deleted or overwritten.
   # Order of includes/excludes/filters is EXTREMELY important
-  rsync --dry-run \
-        -auzxi --delete --exclude "/$DOT_DIR" --exclude-from "$TMP_DIR/fetch-exclude" \
+  cat "$STATE_DIR/added-prev" "$TMP_DIR/local-add-del" \
+  | rsync --dry-run \
+        -auzxi --delete --exclude "/$DOT_DIR" --exclude-from - \
         $USER_RULES $REMOTE/ . \
   | while read line; do
-    if [[ "$line" =~ ^[ch\<\>]f(cs|.s|c.)|^\*deleting ]]; then
+    if [[ "$line" =~ ^[ch\<\>]f|^\*deleting ]]; then
       filename=$(sed "s:^\S*\s*::" <<< "$line" | sed 's:\d96:\\\`:g')
-      if [ -f "$filename" ]; then
-        echo "  | $filename"
-        cp --parents "$filename" "$DOT_DIR"/backups/$TIMESTAMP || die "BACKUP"
+      if [[ -f "$filename" ]]; then
+        echo "  \`- $filename"
+        cp --parents -p "$filename" "$DOT_DIR"/backups/$TIMESTAMP || die "BACKUP"
       fi
     fi
   done
@@ -196,7 +210,7 @@ function sync {
   echo
   echo "# Saving after-sync state and cleaning up"
   rsync -av --list-only --exclude "/$DOT_DIR" $USER_RULES . | grep "^-\|^d" \
-      | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:^/\.::" | sort > "$TMP_DIR/tree-after"
+      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" | sort > "$TMP_DIR/tree-after"
 
   # Save all newly created files for next run (to prevent deletion of them)
   # This includes files created by user in parallel to sync and files fetched from remote

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -150,6 +150,11 @@ function pull() {
         echo "/$filename" >> "$TMP_DIR/tree-after"
       fi
     fi
+    # Drop trailing slash from folders so the contents are not recursively
+    # pulled
+    if [[ -d "$filename" && ${filename: -1} == '/' ]]; then
+      filename="${filename:0:-1}"
+    fi
     # Sync the file. Use a NULL byte delimiter
     printf '%s\0' "$filename"
   done \

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,10 @@ def rm(path)
   FileUtils.rm(path)
 end
 
+def mv(a, b)
+  FileUtils.mv(a, b)
+end
+
 RSpec::Matchers.define :exist do
   match do |filename|
     File.exist?(filename)

--- a/spec/sync_spec.rb
+++ b/spec/sync_spec.rb
@@ -75,4 +75,27 @@ describe 'bitpocket sync' do
     local_path('a').should_not exist
     remote_path('a').should_not exist
   end
+
+  it 'handles remote deletes between syncs' do
+    touch remote_path('a/c')
+    touch remote_path('a/f')
+
+    sync.should succeed
+
+    # After the sync, 'c' and 'f' are in 'added-prev', so they are excluded
+    # from the next pull
+
+    rm remote_path('a/c')
+    mkdir remote_path('a/b')
+    mv remote_path('a/f'), remote_path('a/b/f')
+
+    sync.should succeed
+
+    local_path('a/c').should_not exist
+    local_path('a/f').should_not exist
+    local_path('a/b/f').should exist
+
+    remote_path('a/c').should_not exist
+    remote_path('a/f').should_not exist
+  end
 end


### PR DESCRIPTION
First of all, thank you for the project. I think it's very promising and very elegantly implemented.

I'll offer my use case first, as it might differ from others' usage of the project. I have two servers, we'll call them A and B. They are network file servers and should accept writes from any client at any time. It is my goal to use `bitpocket` to synchronize the writes between the two boxes. And yes, I'm aware that a cluster file system with distributed locking might be a better option; however, I think that's overly complicated. In our environment, folks don't generally edit the same file at the same time. Having a 10 minute lag between the servers is acceptable. *I'm using the idea to replace Microsoft(R) DFSR (Distributed File System Replication), which works similarly to this project. (with the exception of a GUI)*

When I started testing `bitpocket` I noticed that it deleted files unexpectedly and that it also pushed deleted files back. I believe this is because of how it tracks added and deleted files. Although describing why I think  that is in a few paragraphs is very difficult.

I've adjusted how `bitpocket` works so that it assumes that, after the sync is complete, both of the servers have the same contents. Then, when the sync is performed the next time, a file list from *both* servers is collected and compared against the previous sync listing. A list of locally added and deleted files and remotely deleted files is compiled. These two lists are used for the pull and push to ensure that none of the files is deleted nor resurrected unexpectedly.

*The most significant change here is that the stock version did not use any exclude list for the push.*

I've also adjusted the backup method to run in parallel with the pull sync. This reduces one of the rsyncs between the servers. In my environment, I have about 500G of data in about 250k files. So each rsync between the servers is time consuming. And what's more, there is a bug in recent versions of rsync such that, when extended attributes are synced (`--xattrs`), then the sync time goes from about a minute to about 20 minutes.

I can go into more detail for any of the edits or commits but mainly want to start the conversation. I also don't mind rebasing to change parts of it.

Cheers,