### PR TITLE
Add support for REMOTE_BACKUPS

### DIFF
--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -241,6 +241,17 @@ function push() {
   fi
 }
 
+function scrub_rsync_list {
+    # Capture the 5th column, remove blank lines, drop the `/.` folder/file,
+    # and escape files with `[*?` characters in them
+    sed -En '/^[dl-]/ {
+        s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:
+        /^\/\.$/ b
+        s:([*?[]):\\\1:g
+        p
+    }'
+}
+
 # Do the actual synchronization
 function sync {
   assert_dotdir
@@ -268,16 +279,14 @@ function sync {
   if [[ -s "$STATE_DIR/tree-prev" ]]; then
     echo "  | Root dir: $REMOTE"
     rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES $REMOTE/ \
-      | grep "^[dl-]" \
-      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" \
+      | scrub_rsync_list \
       | sort > "$STATE_DIR/remote-tree-current" &
     local remote_tree_pid=$!
   fi
 
   # Collect the current snapshot of the local tree
   rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES . \
-      | grep "^[dl-]" \
-      | sed -e "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" -e "s:^/\.$::" \
+      | scrub_rsync_list \
       | sort > "$STATE_DIR/tree-current" \
       || die "SNAPSHOT"
 
@@ -285,10 +294,8 @@ function sync {
   if [[ -s "$STATE_DIR/tree-prev" ]]; then
     # Escape rsync filter wildcard characters, remove blank lines
     comm -3 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" \
-    | grep -v '^$' \
-    | sed -E 's:([*?[]):\\\1:g' \
     | tee >(grep '^\S' > "$TMP_DIR/local-del") \
-          >(sed -n "s:^[[:space:]][^$]::p" > "$TMP_DIR/local-add") \
+          >(sed -ne "s:^[[:space:]][^$]::p" > "$TMP_DIR/local-add") \
     > /dev/null
   else
     # In the case of a new sync, where no previous tree snapshot is available,
@@ -303,7 +310,6 @@ function sync {
   if [[ -s "$STATE_DIR/tree-prev" ]]; then
     wait $remote_tree_pid
     comm -23 "$STATE_DIR/tree-prev" "$STATE_DIR/remote-tree-current" \
-    | sed -E 's:([[*?]):\\\1:g' \
     > "$TMP_DIR/remote-del"
   fi
 
@@ -486,8 +492,9 @@ function die {
 # List all files in the sync set
 function list {
   echo -e "${GREEN}bitpocket\x1b\x5b0m will sync the following files:"
-  rsync -av --list-only --exclude "/$DOT_DIR"  $USER_RULES . | grep "^-\|^d" \
-      | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:^/\.::" | sort
+  rsync -av --list-only --exclude "/$DOT_DIR"  $USER_RULES . \
+      | scrub_rsync_list \
+      | sort
 }
 
 function usage {

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -18,6 +18,7 @@ LOCK_DIR="$TMP_DIR/lock"  # Use a lock directory for atomic locks. See the Bash 
 SLOW_SYNC_TIME=10
 SLOW_SYNC_FILE="$TMP_DIR/slow"
 RSYNC_RSH="ssh"
+REMOTE_BACKUPS=false
 
 # Load config file
 [ -f "$CFG_FILE" ] && . "$CFG_FILE"
@@ -63,6 +64,13 @@ USER_RULES="$user_filter $user_include $user_exclude"
 
 TIMESTAMP=$(date "+%Y-%m-%d.%H%M%S")
 
+GREEN=""
+RED=""
+if [[ -t 1 ]]; then
+    GREEN="\x1b\x5b1;32m"
+    RED="\x1b\x5b1;31m"
+fi
+
 export RSYNC_RSH
 
 function init {
@@ -82,6 +90,10 @@ function init {
 ## Host and path of central storage
 REMOTE_HOST=$1
 REMOTE_PATH="$2"
+
+## Backups -----------------------------------
+## Make revisions of files on the REMOTE_HOST in the push phase.
+REMOTE_BACKUPS=false
 
 ## SSH command with options for connecting to \$REMOTE
 # RSYNC_RSH="ssh -p 22 -i $DOT_DIR/id_rsa"
@@ -112,79 +124,106 @@ function pull() {
   echo "# Pulling changes from server"
   echo "# >> Saving current state and backing up files (if needed)"
 
+  local BACKUP_TARGET="$DOT_DIR/backups/$TIMESTAMP"
+  local DO_BACKUP="--backup --backup-dir=$BACKUP_TARGET"
+
   cp "$STATE_DIR/tree-current" "$TMP_DIR/tree-after"
-  touch "$TMP_DIR/pull-delete"
 
   # Create a duplicate of STDOUT for logging of backed-up files, and use fd#4
   # for logging of deleted files, which need to be sorted
-  exec 3>&1
-  exec 4> >(sort > "$TMP_DIR/pull-delete")
+  exec 3> >(sort > "$TMP_DIR/pull-delete")
 
   # Determine what will be fetched from server and make backup
   # copies of any local files to be deleted or overwritten.
   # Order of includes/excludes/filters is EXTREMELY important
-  cat "$TMP_DIR/local-add-del" \
-  | rsync --dry-run \
-        -auzxi --delete --exclude "/$DOT_DIR" --exclude-from=- \
+  rsync -auzxi --delete-delay --exclude "/$DOT_DIR" \
+        --exclude-from="$TMP_DIR/local-add-del" \
+        $DO_BACKUP \
         $RSYNC_OPTS $USER_RULES $REMOTE/ . \
-  | while read line; do
-    filename=$(sed "s:^\S*\s*::" <<< "$line" | sed 's:\d96:\\\`:g')
-    if [[ "$line" =~ ^[ch\<\>][fd]|^\*deleting ]]; then
-      operation=${line%% *}
-      if [[ -f "$filename" ]]; then
-        [[ -d "$DOT_DIR"/backups/$TIMESTAMP ]] \
-          || mkdir -p "$DOT_DIR"/backups/$TIMESTAMP
-        cp --parents -p --reflink=auto "$filename" \
-          "$DOT_DIR"/backups/$TIMESTAMP || die "BACKUP"
-        echo "  B $filename" >&3
-      fi
-      # rsync does not support DELETE via --files-from, so delete inline here
-      # after the backup was made
-      if [[ "$operation" == "*deleting" ]]; then
-        # Only delete locally if deleted remotely
-        if grep -q -x "/$filename" "$TMP_DIR/remote-del"; then
-          echo "  | *deleting   $filename" >&3
-          echo "/$filename" >&4
-          [[ -d "$filename" ]] && rmdir "$filename" || rm "$filename"
-        fi
-        continue
-      elif [[ "$operation" =~ \+\+\+\+$ ]]; then
-        # Mark as added locally
-        echo "/$filename" >> "$TMP_DIR/tree-after"
-      fi
-    fi
-    # Drop trailing slash from folders so the contents are not recursively
-    # pulled
-    if [[ -d "$filename" && ${filename: -1} == '/' ]]; then
-      filename="${filename:0:-1}"
-    fi
-    # Sync the file. Use a NULL byte delimiter
-    printf '%s\0' "$filename"
-  done \
-  | rsync --files-from=- --from0 -auzxi $RSYNC_OPTS $USER_RULES \
-        $REMOTE/ . \
+  | detect_changes \
   | sed "s/^/  | /" || die "PULL"
 
-  # Close extra file descriptors
-  exec 4>&-
-  exec 3>&-
+  if [[ -d "$BACKUP_TARGET" ]]
+  then
+      if [[ -n $(find "$BACKUP_TARGET" -type f) ]]
+      then
+          echo "  | Some files were backed up to $BACKUP_TARGET"
+      else
+          # Some versions of rsync will create the backup dir, even if it doesn't
+          # get populated with any backups
+          rmdir "$BACKUP_TARGET"
+      fi
+  fi
 
-  [[ -d "$DOT_DIR"/backups/$TIMESTAMP ]] \
-    && echo "  | Some files were backed up to $DOT_DIR/backups/$TIMESTAMP"
+  exec 3>&-
+}
+
+function detect_changes() {
+    # Read file names from STDIN, and, if they exist locally, create a backup
+    # of each of the files. If they are requested to be deleted (indicated by
+    # the tag at the line beginning), then they are deleted here. Write the
+    # filenames to STDOUT which need to be synchronized by `rsync`
+    while read line
+    do
+        filename="${line#* }"
+        filename="${filename//\`/\\\`}"
+        operation=${line%% *}
+        if [[ "$operation" == "*deleting" ]]
+        then
+            # Only delete locally if deleted remotely
+            if grep -q -x "/$filename" "$TMP_DIR/remote-del"
+            then
+                # Delete here rather than syncing
+                echo "/$filename" >&3
+            fi
+        elif [[ "$operation" =~ \+\+\+\+$ ]]
+        then
+            # Mark as added locally
+            echo "/$filename" >> "$TMP_DIR/tree-after"
+        fi
+    done
 }
 
 function push() {
   # Actual push
+
   # Send new and updated, remotely remove files deleted locally
   # Order of includes/excludes/filters is EXTREMELY important
   echo
   echo "# Pushing changes to server"
 
+  local BACKUP_TARGET="$DOT_DIR/backups/$TIMESTAMP"
+  local DO_BACKUP=""
+  if [[ $REMOTE_BACKUPS == true ]]
+  then
+      echo "# >> Saving current state and backing up files (if needed)"
+      DO_BACKUP="--backup --backup-dir=$BACKUP_TARGET"
+  fi
+
   # Do not push back remotely deleted files
-  cat "$TMP_DIR/remote-del" \
-  | rsync -auzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" \
-      --exclude-from - $USER_RULES . $REMOTE/ \
+  rsync -auzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" \
+      --exclude-from="$TMP_DIR/remote-del" \
+      $DO_BACKUP \
+      $USER_RULES . $REMOTE/ \
   | sed "s/^/  | /" || die "PUSH"
+
+  if [[ $REMOTE_BACKUPS == true ]]
+  then
+      $REMOTE_RUNNER "
+      cd '$REMOTE_PATH'
+      if [[ -d '$BACKUP_TARGET' ]]
+      then
+	  if [[ -n \$(find '$BACKUP_TARGET' -type f) ]]
+	  then
+	      echo '  | Some files were backed up to $BACKUP_TARGET'
+	  else
+	      # Some versions of rsync will create the backup dir, even if it doesn't
+	      # get populated with any backups
+	      rmdir '$BACKUP_TARGET'
+	  fi
+      fi
+      "
+  fi
 }
 
 # Do the actual synchronization
@@ -194,7 +233,7 @@ function sync {
   acquire_remote_lock
 
   echo
-  echo -e "\x1b\x5b1;32mbitpocket started\x1b\x5b0m at `date`."
+  echo -e "${GREEN}bitpocket started\x1b\x5b0m at `date`."
   echo
 
   # Fire off slow sync start notifier in background
@@ -263,11 +302,10 @@ function sync {
 
   cleanup
   echo
-  echo -e "\x1b\x5b1;32mbitpocket finished\x1b\x5b0m at `date`."
+  echo -e "${GREEN}bitpocket finished\x1b\x5b0m at `date`."
   echo
 
 }
-
 
 # Pack backups into a git repository
 function pack {
@@ -362,7 +400,7 @@ function acquire_lock {
       echo "There's already an instance of BitPocket syncing this directory. Exiting."
       exit 1
     else
-      echo -e "\x1b\x5b1;31mbitpocket error:\x1b\x5b0m Bitpocket found a stale lock directory:"
+      echo -e "${RED}bitpocket error:\x1b\x5b0m Bitpocket found a stale lock directory:"
       echo "  | Root dir: $(pwd)"
       echo "  | Lock dir: $LOCK_DIR"
       echo "  | Command:  LOCK_PATH=$(pwd)/$LOCK_DIR && rm \$LOCK_PATH/pid && rmdir \$LOCK_PATH"
@@ -423,7 +461,7 @@ function die {
 
 # List all files in the sync set
 function list {
-  echo -e "\x1b\x5b1;32mbitpocket\x1b\x5b0m will sync the following files:"
+  echo -e "${GREEN}bitpocket\x1b\x5b0m will sync the following files:"
   rsync -av --list-only --exclude "/$DOT_DIR"  $USER_RULES . | grep "^-\|^d" \
       | sed "s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:" | sed "s:^/\.::" | sort
 }
@@ -461,6 +499,8 @@ elif [ "$1" = "cron" ]; then
 elif [ "$1" = "list" ]; then
   # List all file in sync set (honoring .bitpocket/include & .bitpocket/exclude)
   list
+elif [ "$1" = "remote-pull" ]; then
+  remote_pull $2 "$3"
 elif [ "$1" != "" ] && [ "$1" != "sync" ]; then
   # Show help
   usage

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -151,9 +151,10 @@ function pull() {
   cat "$TMP_DIR/remote-del" \
   | prefix "R " \
   | rsync -auzxi --delete --exclude "/$DOT_DIR" \
-        --exclude-from="$TMP_DIR/local-add-del" \
-	--filter=". -" \
-	--filter="P **" \
+        --exclude-from="$TMP_DIR/local-add" \
+        --exclude-from="$TMP_DIR/local-del" \
+        --filter=". -" \
+        --filter="P **" \
         $DO_BACKUP \
         $RSYNC_OPTS $USER_RULES $REMOTE/ . \
   | detect_changes \
@@ -213,10 +214,13 @@ function push() {
   fi
 
   # Do not push back remotely deleted files
-  rsync -auzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" \
-      --exclude-from="$TMP_DIR/remote-del" \
-      $DO_BACKUP \
-      $USER_RULES . $REMOTE/ \
+  prefix "R " < "$TMP_DIR/local-del" \
+  | rsync -auzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" \
+        --exclude-from="$TMP_DIR/remote-del" \
+        --filter=". -" \
+        --filter="P **" \
+        $DO_BACKUP \
+        $USER_RULES . $REMOTE/ \
   | sed "s/^/  | /" || die "PUSH"
 
   if [[ $REMOTE_BACKUPS == true ]]
@@ -280,11 +284,16 @@ function sync {
 
   # Prevent bringing back locally deleted files
   if [[ -s "$STATE_DIR/tree-prev" ]]; then
-    comm -3 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" | sed -e "s:^[^/]*::" > "$TMP_DIR/local-add-del"
+    comm -3 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" \
+    | grep -v '^$' \
+    | tee >(grep '^\S' > "$TMP_DIR/local-del") \
+          >(sed -n "s:^[[:space:]][^$]::p" > "$TMP_DIR/local-add") \
+    > /dev/null
   else
     # In the case of a new sync, where no previous tree snapshot is available,
     # assume all the files on the local side should be protected
-    cp "$STATE_DIR/tree-current" "$TMP_DIR/local-add-del"
+    cp "$STATE_DIR/tree-current" "$TMP_DIR/local-add"
+    touch "$TMP_DIR/local-del"
   fi
 
   # Prevent deleting local files which were not deleted remotely

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -116,6 +116,13 @@ function log {
   tail -f "$DOT_DIR/log"
 }
 
+function prefix() {
+    while read line
+    do
+        echo "$1$line"
+    done
+}
+
 function pull() {
   # Actual fetch
   # Pulling changes from server
@@ -133,11 +140,20 @@ function pull() {
   # for logging of deleted files, which need to be sorted
   exec 3> >(sort > "$TMP_DIR/pull-delete")
 
-  # Determine what will be fetched from server and make backup
-  # copies of any local files to be deleted or overwritten.
+  # Determine what will be fetched from server and make backup copies of any
+  # local files to be deleted or overwritten.
+  #
+  # Only delete locally if deleted remotely. To do this, use the remote-del
+  # file to set the *R*isk filter flag (allow delete), and protect everything
+  # else with the *P*rotect flag.
+  #
   # Order of includes/excludes/filters is EXTREMELY important
-  rsync -auzxi --delete-delay --exclude "/$DOT_DIR" \
+  cat "$TMP_DIR/remote-del" \
+  | prefix "R " \
+  | rsync -auzxi --delete --exclude "/$DOT_DIR" \
         --exclude-from="$TMP_DIR/local-add-del" \
+	--filter=". -" \
+	--filter="P **" \
         $DO_BACKUP \
         $RSYNC_OPTS $USER_RULES $REMOTE/ . \
   | detect_changes \
@@ -170,12 +186,8 @@ function detect_changes() {
         operation=${line%% *}
         if [[ "$operation" == "*deleting" ]]
         then
-            # Only delete locally if deleted remotely
-            if grep -q -x "/$filename" "$TMP_DIR/remote-del"
-            then
-                # Delete here rather than syncing
-                echo "/$filename" >&3
-            fi
+            # Mark as locally deleted
+	    echo "/$filename" >&3
         elif [[ "$operation" =~ \+\+\+\+$ ]]
         then
             # Mark as added locally

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -117,7 +117,7 @@ function log {
 }
 
 function prefix() {
-    while read line
+    while read -r line
     do
         echo "$1$line"
     done
@@ -148,8 +148,7 @@ function pull() {
   # else with the *P*rotect flag.
   #
   # Order of includes/excludes/filters is EXTREMELY important
-  cat "$TMP_DIR/remote-del" \
-  | prefix "R " \
+  prefix "R " < "$TMP_DIR/remote-del" \
   | rsync -auzxi --delete --exclude "/$DOT_DIR" \
         --exclude-from="$TMP_DIR/local-add" \
         --exclude-from="$TMP_DIR/local-del" \
@@ -180,7 +179,7 @@ function detect_changes() {
     # of each of the files. If they are requested to be deleted (indicated by
     # the tag at the line beginning), then they are deleted here. Write the
     # filenames to STDOUT which need to be synchronized by `rsync`
-    while read line
+    while read -r line
     do
         filename="${line#* }"
         filename="${filename//\`/\\\`}"
@@ -284,8 +283,10 @@ function sync {
 
   # Prevent bringing back locally deleted files
   if [[ -s "$STATE_DIR/tree-prev" ]]; then
+    # Escape rsync filter wildcard characters, remove blank lines
     comm -3 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" \
     | grep -v '^$' \
+    | sed -E 's:([*?[]):\\\1:g' \
     | tee >(grep '^\S' > "$TMP_DIR/local-del") \
           >(sed -n "s:^[[:space:]][^$]::p" > "$TMP_DIR/local-add") \
     > /dev/null
@@ -301,7 +302,9 @@ function sync {
   touch "$TMP_DIR/remote-del"
   if [[ -s "$STATE_DIR/tree-prev" ]]; then
     wait $remote_tree_pid
-    comm -23 "$STATE_DIR/tree-prev" "$STATE_DIR/remote-tree-current" > "$TMP_DIR/remote-del"
+    comm -23 "$STATE_DIR/tree-prev" "$STATE_DIR/remote-tree-current" \
+    | sed -E 's:([[*?]):\\\1:g' \
+    > "$TMP_DIR/remote-del"
   fi
 
   pull

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -23,6 +23,18 @@ REMOTE_BACKUPS=false
 # Load config file
 [ -f "$CFG_FILE" ] && . "$CFG_FILE"
 
+# Colors
+GREEN=""
+RED=""
+CLEAR=""
+YELLOW=""
+if [[ -t 1 ]]; then
+    GREEN="\x1b\x5b1;32m"
+    RED="\x1b\x5b1;31m"
+    YELLOW="\x1b\x5b1;33m"
+    CLEAR="\x1b\x5b0m"
+fi
+
 # Test for GNU versions of core utils. Bail if non-GNU.
 sed --version >/dev/null 2>/dev/null
 if [ $? -ne 0 ]; then
@@ -63,13 +75,6 @@ fi
 USER_RULES="$user_filter $user_include $user_exclude"
 
 TIMESTAMP=$(date "+%Y-%m-%d.%H%M%S")
-
-GREEN=""
-RED=""
-if [[ -t 1 ]]; then
-    GREEN="\x1b\x5b1;32m"
-    RED="\x1b\x5b1;31m"
-fi
 
 export RSYNC_RSH
 
@@ -161,7 +166,7 @@ function pull() {
 
   if [[ -d "$BACKUP_TARGET" ]]
   then
-      if [[ -n $(find "$BACKUP_TARGET" -type f) ]]
+      if [[ -n "$(find "$BACKUP_TARGET" -type f)" ]]
       then
           echo "  | Some files were backed up to $BACKUP_TARGET"
       else
@@ -193,6 +198,7 @@ function detect_changes() {
             # Mark as added locally
             echo "/$filename" >> "$TMP_DIR/tree-after"
         fi
+        echo "$line"
     done
 }
 
@@ -228,14 +234,14 @@ function push() {
       cd '$REMOTE_PATH'
       if [[ -d '$BACKUP_TARGET' ]]
       then
-	  if [[ -n \$(find '$BACKUP_TARGET' -type f) ]]
-	  then
-	      echo '  | Some files were backed up to $BACKUP_TARGET'
-	  else
-	      # Some versions of rsync will create the backup dir, even if it doesn't
-	      # get populated with any backups
-	      rmdir '$BACKUP_TARGET'
-	  fi
+          if [[ -n \"\$(find '$BACKUP_TARGET' -type f)\" ]]
+          then
+              echo '  | Some files were backed up to $BACKUP_TARGET'
+          else
+              # Some versions of rsync will create the backup dir, even if it doesn't
+              # get populated with any backups
+              rmdir '$BACKUP_TARGET'
+          fi
       fi
       "
   fi
@@ -246,7 +252,7 @@ function scrub_rsync_list {
     # and escape files with `[*?` characters in them
     sed -En '/^[dl-]/ {
         s:^\S*\s*\S*\s*\S*\s*\S*\s*:/:
-        /^\/\.$/ b
+        /^\/\.$/ d
         s:([*?[]):\\\1:g
         p
     }'
@@ -259,7 +265,7 @@ function sync {
   acquire_remote_lock
 
   echo
-  echo -e "${GREEN}bitpocket started\x1b\x5b0m at `date`."
+  echo -e "${GREEN}bitpocket started${CLEAR} at `date`."
   echo
 
   # Fire off slow sync start notifier in background
@@ -295,8 +301,7 @@ function sync {
     # Escape rsync filter wildcard characters, remove blank lines
     comm -3 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" \
     | tee >(grep '^\S' > "$TMP_DIR/local-del") \
-          >(sed -ne "s:^[[:space:]][^$]::p" > "$TMP_DIR/local-add") \
-    > /dev/null
+    | sed -ne "s:^[[:space:]][^$]::p" > "$TMP_DIR/local-add"
   else
     # In the case of a new sync, where no previous tree snapshot is available,
     # assume all the files on the local side should be protected
@@ -332,7 +337,7 @@ function sync {
 
   cleanup
   echo
-  echo -e "${GREEN}bitpocket finished\x1b\x5b0m at `date`."
+  echo -e "${GREEN}bitpocket finished${CLEAR} at `date`."
   echo
 
 }
@@ -430,7 +435,7 @@ function acquire_lock {
       echo "There's already an instance of BitPocket syncing this directory. Exiting."
       exit 1
     else
-      echo -e "${RED}bitpocket error:\x1b\x5b0m Bitpocket found a stale lock directory:"
+      echo -e "${RED}bitpocket error:${CLEAR} Bitpocket found a stale lock directory:"
       echo "  | Root dir: $(pwd)"
       echo "  | Lock dir: $LOCK_DIR"
       echo "  | Command:  LOCK_PATH=$(pwd)/$LOCK_DIR && rm \$LOCK_PATH/pid && rmdir \$LOCK_PATH"
@@ -491,7 +496,7 @@ function die {
 
 # List all files in the sync set
 function list {
-  echo -e "${GREEN}bitpocket\x1b\x5b0m will sync the following files:"
+  echo -e "${GREEN}bitpocket${CLEAR} will sync the following files:"
   rsync -av --list-only --exclude "/$DOT_DIR"  $USER_RULES . \
       | scrub_rsync_list \
       | sort

--- a/spec/sync_spec.rb
+++ b/spec/sync_spec.rb
@@ -98,4 +98,42 @@ describe 'bitpocket sync' do
     remote_path('a/c').should_not exist
     remote_path('a/f').should_not exist
   end
+
+  it 'does not remove new local files which contain []`*?' do
+    touch remote_path('a*')
+    touch remote_path('b?')
+
+    sync.should succeed
+
+    local_path('a*').should exist
+    remote_path('a*').should exist
+    local_path('b?').should exist
+    remote_path('b?').should exist
+
+    touch local_path('[]')
+    touch local_path('`hello')
+
+    sync.should succeed
+
+    local_path('[]').should exist
+    remote_path('[]').should exist
+    local_path('`hello').should exist
+    remote_path('`hello').should exist
+
+    rm local_path('[]')
+    rm local_path('`hello')
+    rm remote_path('a*')
+    rm remote_path('b?')
+
+    sync.should succeed
+
+    local_path('a*').should_not exist
+    remote_path('a*').should_not exist
+    local_path('b?').should_not exist
+    remote_path('b?').should_not exist
+    local_path('[]').should_not exist
+    remote_path('[]').should_not exist
+    local_path('`hello').should_not exist
+    remote_path('`hello').should_not exist
+  end
 end


### PR DESCRIPTION
This allows the remote host to cooperate with the PUSH process and create backups on the remote host itself, for files which will be overwritten by the PUSH. Backups are already created in the pull process. This adds the same feature on the remote server.

It works by copying `bitpocket` to the remote server and running it. Then it sends the file names it wants to push to the bitpocket process on the remote server. Then the remote server uses the `backup_inline` function to handle creating backups exactly the same as what happens in the pull process.

Addreses #53

### Outstanding
- [ ] Support for sending BACKUP_EXCLUDE settings to the remote host (if the feature/backup-exclude is merged)
- [x] Pass all the rake tests with REMOTE_BACKUPS=true
- [x] Find the lurking `rmdir` error when cleaning the (non-)empty backup folder