### PR TITLE
test: Add test to cover fail described by @jordan-stone

### DIFF
--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -344,9 +344,28 @@ function analyse {
       # Honor local mode changes (link to file, as well as permissions).
       # These should be protected in the pull phase. Ignore files already
       # masked as locally added or locally removed.
-      comm -23 <(sort "$STATE_DIR/tree-current") <(sort "$STATE_DIR/tree-prev") \
-      | strip_mode \
-      > "$TMP_DIR/local-add-change"
+      if [[ $STATE_VERSION > 1 ]]
+      then
+          # Use comm to detect the differences in the pseudo-sorted files
+          # (they're sorted on column 12). Comm will detect some false
+          # positives, so run the output back through `grep` to check if there
+          # is an exact match in the previous state file. This is much faster
+          # than resorting both of the files if they are somewhat large.
+          comm -23 "$STATE_DIR/tree-current" "$STATE_DIR/tree-prev" 2>/dev/null \
+          | while read -r line
+            do
+                if ! grep -Fxq "$line" "$STATE_DIR/tree-prev"
+                then
+                    echo "$line"
+                fi
+            done \
+          | strip_mode \
+          > "$TMP_DIR/local-add-change"
+      else
+          # In transition to the new state file, ignore the changes in mode
+          comm -23 <(strip_mode < "$STATE_DIR/tree-current") "$STATE_DIR/tree-prev" \
+          > "$TMP_DIR/local-add-change"
+      fi
 
       # Also protect the folders where files were locally added and removed so
       # that the modify times of them are not reverted to the remote ones
@@ -382,10 +401,7 @@ function strip_mode {
         cut -c12-
     else
         # State file version might be intermixed. Evaluate each line
-        while read -r line
-        do
-            [[ ${line:0:1} == ":" ]] && echo "${line:11}" || echo "$line"
-        done
+        sed -E "s/^:.{10}//"
     fi
 }
 

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -42,6 +42,7 @@ if [[ -t 1 ]]; then
 fi
 
 # Test for GNU versions of core utils. Bail if non-GNU.
+BSD=false
 sed --version >/dev/null 2>/dev/null
 if [[ $? -eq 0 ]]; then
     alias cp="cp --parents --reflink=auto"
@@ -53,6 +54,7 @@ may not work correctly on this platform. Please beware and report any issues
 you encounter.
 "
     alias sed="sed -E"
+    BSD=true
 fi
 
 # Decide on runner (ssh / bash -c)
@@ -63,6 +65,16 @@ else
   REMOTE_RUNNER="bash -c"
   REMOTE="$REMOTE_PATH"
 fi
+
+# Version of the state files. Original version is 1, second version with
+# leading mode is 2.
+#
+# Current state version is 2, and the format of the state file is
+# ":" TYPE MODE "/" PATH "\n"
+# Where TYPE = ("-" | "d" | "l" )
+#       MODE = unix mode (9-character) (like "rw-rw-r--")
+#       PATH = relative full-path of file
+STATE_VERSION=2
 
 REMOTE_TMP_DIR="$REMOTE_PATH/$DOT_DIR/tmp"
 
@@ -170,10 +182,6 @@ function pull() {
 
   cp "$STATE_DIR/tree-current" "$TMP_DIR/tree-after"
 
-  # Create a duplicate of STDOUT for logging of backed-up files, and use fd#4
-  # for logging of deleted files, which need to be sorted
-  exec 3> >(sort > "$TMP_DIR/pull-delete")
-
   # Determine what will be fetched from server and make backup copies of any
   # local files to be deleted or overwritten.
   #
@@ -182,13 +190,17 @@ function pull() {
   # else with the *P*rotect flag.
   #
   # Order of includes/excludes/filters is EXTREMELY important
+  #
+  # TODO: Consider adding %U and %G to the output format to capture owner and
+  # group changes
   prefix "R " < "$TMP_DIR/remote-del" \
-  | rsync -auzxi --delete --exclude "/$DOT_DIR" \
-        --exclude-from="$TMP_DIR/local-add" \
+  | rsync -auzx --delete --exclude "/$DOT_DIR" \
         --exclude-from="$TMP_DIR/local-del" \
+        --exclude-from="$TMP_DIR/local-add-change" \
         --filter=". -" \
         --filter="P **" \
         $DO_BACKUP \
+        --out-format=%i:%B:%n \
         $RSYNC_OPTS $USER_RULES $REMOTE/ . \
   | detect_changes \
   | prefix "  | " || die "PULL"
@@ -204,31 +216,33 @@ function pull() {
           rmdir "$BACKUP_TARGET"
       fi
   fi
-
-  exec 3>&-
 }
 
 function detect_changes() {
-    # Read file names from STDIN, and, if they exist locally, create a backup
-    # of each of the files. If they are requested to be deleted (indicated by
-    # the tag at the line beginning), then they are deleted here. Write the
-    # filenames to STDOUT which need to be synchronized by `rsync`
+    # Create a duplicate of STDOUT for logging of backed-up files, and use fd#4
+    # for logging of deleted files, which need to be sorted
+    exec 3> >(sort > "$TMP_DIR/pull-delete")
+
     while read -r line
     do
-        filename="${line#* }"
-        filename="${filename//\`/\\\`}"
-        operation=${line%% *}
-        if [[ "$operation" == "*deleting" ]]
+        IFS=":" info=($line)
+        operation=${info[0]}
+        filename="${info[@]:2}"
+        if [[ "$operation" =~ ^\*deleting ]]
         then
-            # Mark as locally deleted
-	    echo "/$filename" >&3
+            grep -F "/$filename" "$STATE_DIR/tree-current" >&3
         elif [[ "$operation" =~ \+\+\+\+$ ]]
         then
-            # Mark as added locally
-            echo "/$filename" >> "$TMP_DIR/tree-after"
+            # Mark as added locally (with proper mode)
+            mode=${info[1]}
+            filetype="${operation:1:1}"
+            filetype="${filetype/f/-}"
+            echo ":${filetype}${mode}/$filename" >> "$TMP_DIR/tree-after"
         fi
-        echo "$line"
+        echo "$operation $filename"
     done
+
+    exec 3>&-
 }
 
 function push() {
@@ -277,11 +291,13 @@ function push() {
 }
 
 function scrub_rsync_list {
-    # Capture the 5th column, remove blank lines, drop the `/.` folder/file,
-    # and escape files with `[*?` characters in them
+    # Capture the 1st and 5th columns (mode and file name), remove blank lines,
+    # drop the `/.` folder/file, and escape files with `[*?` characters in
+    # them. Use the ASCII "file separator" (0x1c) to separate the filename from
+    # the file mode in the output.
     sed -En '/^[dl-]/ {
-        s:^[^[:space:]]*[[:space:]]*[^[:space:]]*[[:space:]]*[^[:space:]]*[[:space:]]*[^[:space:]]*[[:space:]]*:/:
-        /^\/\.$/ d
+        s:^([^[:space:]]*)[[:space:]]*[^[:space:]]*[[:space:]]*[^[:space:]]*[[:space:]]*[^[:space:]]*[[:space:]]*(.*$):\:\1/\2:
+        /\/\.$/ b
         s:([*?[]):\\\1:g
         p
     }'
@@ -303,51 +319,74 @@ function analyse {
     echo "  | Root dir: $REMOTE"
     rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES $REMOTE/ \
       | scrub_rsync_list \
-      | sort > "$STATE_DIR/remote-tree-current" &
+      | sort -k 1.12 \
+      > "$STATE_DIR/remote-tree-current" &
     local remote_tree_pid=$!
   fi
 
   # Collect the current snapshot of the local tree
   rsync --list-only --recursive --exclude "/$DOT_DIR" $USER_RULES . \
       | scrub_rsync_list \
-      | sort > "$STATE_DIR/tree-current" \
+      | sort -k 1.12 \
+      > "$STATE_DIR/tree-current" \
       || die "SNAPSHOT"
 
   # Prevent bringing back locally deleted files
-  if [[ -s "$STATE_DIR/tree-prev" ]]; then
-    # Escape rsync filter wildcard characters, remove blank lines
-    comm -3 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" \
-    | tee >(grep '^\S' > "$TMP_DIR/local-del") \
-    | sed -ne "s:^[[:space:]][^$]::p" > "$TMP_DIR/local-add"
+  if [[ -s "$STATE_DIR/tree-prev" ]]
+  then
+      # Compile a list of files added locally and removed locally. These
+      # should be protected in the pull phase. Escape rsync filter wildcard
+      # characters, remove blank lines
+      strip_mode < "$STATE_DIR/tree-prev" \
+      | comm -23 - <(strip_mode < "$STATE_DIR/tree-current") \
+      > "$TMP_DIR/local-del"
 
-    # Also protect the folders where files were locally added and removed so
-    # that the modify times of them are not reverted to the remote ones
-    cat "$TMP_DIR/local-del" "$TMP_DIR/local-add" \
-    | while read -r line; do
-        # Only parent folders of files--not folders
-        if [[ "${line: -1}" != "/" ]]
-        then
-            echo "${line%/*}/"
-        fi
-      done \
-    | sort -u \
-    >> "$TMP_DIR/local-add"
+      # Honor local mode changes (link to file, as well as permissions).
+      # These should be protected in the pull phase. Ignore files already
+      # masked as locally added or locally removed.
+      comm -23 <(sort "$STATE_DIR/tree-current") <(sort "$STATE_DIR/tree-prev") \
+      | strip_mode \
+      > "$TMP_DIR/local-add-change"
+
+      # Also protect the folders where files were locally added and removed so
+      # that the modify times of them are not reverted to the remote ones
+      cat "$TMP_DIR/local-del" "$TMP_DIR/local-add-change" \
+      | while read -r line; do
+          # Only parent folders of files--not folders
+          if [[ "${line: -1}" != "/" ]]
+          then
+              echo "${line%/*}/"
+          fi
+        done \
+      | sort -u \
+      >> "$TMP_DIR/local-add-change"
+
+      # Prevent deleting local files which were not deleted remotely ie.
+      # prevent deleting newly added local files. Compile a list of remotely
+      # deleted files which should be protected in the push phase.
+      wait $remote_tree_pid
+      strip_mode < "$STATE_DIR/tree-prev" \
+      | comm -23 - <(strip_mode < "$STATE_DIR/remote-tree-current") \
+      > "$TMP_DIR/remote-del"
   else
-    # In the case of a new sync, where no previous tree snapshot is available,
-    # assume all the files on the local side should be protected
-    cp "$STATE_DIR/tree-current" "$TMP_DIR/local-add"
-    touch "$TMP_DIR/local-del"
+      # In the case of a new sync, where no previous tree snapshot is available,
+      # assume all the files on the local side should be protected
+      cp "$STATE_DIR/tree-current" "$TMP_DIR/local-add-change"
+      touch "$TMP_DIR/local-del"
+      touch "$TMP_DIR/remote-del"
   fi
+}
 
-  # Prevent deleting local files which were not deleted remotely
-  # ie. Prevent deleting newly added local files
-  touch "$TMP_DIR/remote-del"
-  if [[ -s "$STATE_DIR/tree-prev" ]]; then
-    wait $remote_tree_pid
-    comm -23 "$STATE_DIR/tree-prev" "$STATE_DIR/remote-tree-current" \
-    | grep -v '^[[:space:]]*$' \
-    > "$TMP_DIR/remote-del"
-  fi
+function strip_mode {
+    if [[ $STATE_VERSION > 1 ]]; then
+        cut -c12-
+    else
+        # State file version might be intermixed. Evaluate each line
+        while read -r line
+        do
+            [[ ${line:0:1} == ":" ]] && echo "${line:11}" || echo "$line"
+        done
+    fi
 }
 
 # Do the actual synchronization
@@ -355,6 +394,7 @@ function sync {
   assert_dotdir
   acquire_lock
   acquire_remote_lock
+  check_state_version
 
   echo
   echo -e "${GREEN}bitpocket started${CLEAR} at `date`."
@@ -378,13 +418,14 @@ function sync {
 
       # Generate a incremental snapshot of the local tree including files deleted
       # and added via the pull()
+      #
+      # Remove pull-deleted files from the tree-after snapshot
       sort "$TMP_DIR/tree-after" \
-      | comm -13 "$TMP_DIR/pull-delete" - \
-      | sed -e "s:^[[:space:]]*::" -e "s:/\$::" \
+      | comm -23 - "$TMP_DIR/pull-delete" \
+      | sed -e "s:/\$::" \
       > "$STATE_DIR/tree-prev"
-
-      rm "$TMP_DIR/tree-after"
   fi
+  rm "$TMP_DIR/tree-after"
 
   # Fire off slow sync stop notifier in background
   on_slow_sync_stop
@@ -533,6 +574,22 @@ function cleanup {
   release_remote_lock
 }
 
+##
+# Inspect the state file tree-prev to see if the format of the file is the
+# current version (2) or the original version (1). This is used in the
+# `strip_mode` function to optimize the sync process when the `tree-prev` file
+# uses the current state version.
+function check_state_version() {
+    # In the original state files, the start of the line was the filename with
+    # a leading slash
+    if [[ -s "$STATE_DIR/tree-prev" ]]; then
+        local first=$(head -1 "$STATE_DIR/tree-prev" 2>/dev/null)
+        if [[ ${first:0:1} == "/" ]]; then
+            STATE_VERSION=1
+        fi
+    fi
+}
+
 function bring_the_children_let_me_kill_them {
   if [ -n "$shell_pid" ]; then
     pkill -P $shell_pid &>/dev/null
@@ -553,6 +610,7 @@ function list {
   echo -e "${GREEN}bitpocket${CLEAR} will sync the following files:"
   rsync -av --list-only --exclude "/$DOT_DIR"  $USER_RULES . \
       | scrub_rsync_list \
+      | strip_mode \
       | sort
 }
 

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -221,7 +221,7 @@ function pull() {
 function detect_changes() {
     # Create a duplicate of STDOUT for logging of backed-up files, and use fd#4
     # for logging of deleted files, which need to be sorted
-    exec 3> >(sort > "$TMP_DIR/pull-delete")
+    exec 3> >(grep -Ff /dev/stdin "$STATE_DIR/tree-current" | sort > "$TMP_DIR/pull-delete")
 
     while read -r line
     do
@@ -230,7 +230,7 @@ function detect_changes() {
         filename="${info[@]:2}"
         if [[ "$operation" =~ ^\*deleting ]]
         then
-            grep -F "/$filename" "$STATE_DIR/tree-current" >&3
+            echo "/${filename}" >&3
         elif [[ "$operation" =~ \+\+\+\+$ ]]
         then
             # Mark as added locally (with proper mode)

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -420,7 +420,7 @@ function sync {
       # and added via the pull()
       #
       # Remove pull-deleted files from the tree-after snapshot
-      sort "$TMP_DIR/tree-after" \
+      sort -k1.12 "$TMP_DIR/tree-after" \
       | comm -23 - "$TMP_DIR/pull-delete" \
       | sed -e "s:/\$::" \
       > "$STATE_DIR/tree-prev"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,10 @@ def mv(a, b)
   FileUtils.mv(a, b)
 end
 
+def ln(a,b )
+  FileUtils.ln_s(a, b)
+end
+
 RSpec::Matchers.define :exist do
   match do |filename|
     File.exist?(filename)

--- a/spec/sync_spec.rb
+++ b/spec/sync_spec.rb
@@ -155,7 +155,7 @@ describe 'bitpocket sync' do
 
   it 'does not remove soft link when -L is not set' do
     cat content, local_path('b')
-    ln local_path('b'), local_path('a')
+    ln 'b', local_path('a')
 
     sync.should succeed
 

--- a/spec/sync_spec.rb
+++ b/spec/sync_spec.rb
@@ -152,4 +152,23 @@ describe 'bitpocket sync' do
 
     File.mtime(local_path('a/')).should == Time.new(2008,1,12,0,0)
   end
+
+  it 'does not remove soft link when -L is not set' do
+    cat content, local_path('b')
+    ln local_path('b'), local_path('a')
+
+    sync.should succeed
+
+    remote_path('a').should exist
+    remote_path('b').should exist
+
+    File.read(remote_path('a')).should == content
+
+    rm local_path('a')
+    cat content + content, local_path('a')
+
+    sync.should succeed
+
+    File.read(remote_path('a')).should == content + content
+  end
 end

--- a/spec/sync_spec.rb
+++ b/spec/sync_spec.rb
@@ -171,4 +171,28 @@ describe 'bitpocket sync' do
 
     File.read(remote_path('a')).should == content + content
   end
+
+  it 'correcly handles remote deletes with old state files' do
+    cat 'hello', local_path('a')
+    cat 'hello', local_path('b')
+    sync.should succeed
+
+    cat "/a\n/b\n", local_path('.bitpocket/state/tree-prev')
+    rm remote_path('b')
+    sync.should succeed
+
+    local_path('b').should_not exist
+    remote_path('a').should exist
+  end
+
+  it 'correcly handles remote updates with old state files' do
+    cat 'hello', local_path('b')
+    sync.should succeed
+
+    cat "/b\n", local_path('.bitpocket/state/tree-prev')
+    cat 'hello2', remote_path('b')
+    sync.should succeed
+
+    File.read(local_path('b')).should == 'hello2'
+  end
 end


### PR DESCRIPTION
This is a continuation from #51. @jordan-stone discovered an issue with syncing of folders with symbolic links. Part of the issue has been resolved. This is a test case he discovered which still exists.

1. If I create a link in my local BitPocket directory and then sync to master,
1. unlink the link, but then create a normal file with the same name in my local Bitpocket directory
1. sync to master again.

After the last step, the local content has been replaced with the link again. 

This patch confirms the issue still exists in Bitpocket. A fix has yet to be discovered