### PR TITLE
pull: Add protection for local folders having local changes

### DIFF
--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -319,6 +319,15 @@ function analyse {
     comm -3 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" \
     | tee >(grep '^\S' > "$TMP_DIR/local-del") \
     | sed -ne "s:^[[:space:]][^$]::p" > "$TMP_DIR/local-add"
+
+    # Also protect the folders where files were locally added and removed so
+    # that the modify times of them are not reverted to the remote ones
+    cat "$TMP_DIR/local-del" "$TMP_DIR/local-add" \
+    | while read -r line; do
+        echo "${line%/*}/"
+      done \
+    | sort -u \
+    >> "$TMP_DIR/local-add"
   else
     # In the case of a new sync, where no previous tree snapshot is available,
     # assume all the files on the local side should be protected

--- a/spec/sync_spec.rb
+++ b/spec/sync_spec.rb
@@ -136,4 +136,20 @@ describe 'bitpocket sync' do
     local_path('`hello').should_not exist
     remote_path('`hello').should_not exist
   end
+
+  it 'does not revert modify time of local folders with new files' do
+    touch local_path('a/a')
+    touch remote_path('a/a')
+    sync.should succeed
+
+    touch local_path('a/b')
+    if RUBY_PLATFORM =~ /darwin/
+      system "touch -mt 200801120000 #{local_path('a/')}"
+    else
+      system "touch -t '200801120000' #{local_path('a/')}"
+    end
+    sync.should succeed
+
+    File.mtime(local_path('a/')).should == Time.new(2008,1,12,0,0)
+  end
 end


### PR DESCRIPTION
This protects the folders from the modification time being reverted back to the remote folder's modification time. This happens because the files are protected, not the folder, and somehow folder's are not excluded from rsync's `--update` flag.