### PR TITLE
Wait for 2 minutes while trying to obtain lock on a sync

### DIFF
--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -21,6 +21,7 @@ RSYNC_RSH="ssh"
 REMOTE_BACKUPS=false
 BACKUPS=true
 REMOTE_MOUNTPOINT=false
+LOCK_ACQUIRE_TIMEOUT=60
 
 # Default command-line options and such
 COMMANDS=()
@@ -127,6 +128,9 @@ REMOTE_BACKUPS=false
 
 ## SSH command with options for connecting to \$REMOTE
 # RSYNC_RSH="ssh -p 22 -i $DOT_DIR/id_rsa"
+
+## By default, the program will wait for 60 seconds to acquire a lock on the remote host (in case other clients are currently syncing). Change this value to the desired timeout value in seconds 0 to disable the wait time.
+# LOCK_ACQUIRE_TIMEOUT=60
 
 ## Uncomment following line to follow symlinks (transform it into referent file/dir)
 # RSYNC_OPTS="-L"
@@ -502,16 +506,16 @@ function release_lock {
 }
 
 function acquire_remote_lock {
-  tries=0
+  start=$SECONDS
   $REMOTE_RUNNER "mkdir -p \"$REMOTE_TMP_DIR\"; cd \"$REMOTE_PATH\" && mkdir \"$LOCK_DIR\" 2>/dev/null"
   while [[ $? != 0 ]]; do
-    if [ $tries -gt 20 ]; then
+    duration=$(( $SECONDS - $start ))
+    if [ $duration -gt $LOCK_ACQUIRE_TIMEOUT ] || [ $LOCK_ACQUIRE_TIMEOUT -eq 0 ]; then
       echo "Couldn't acquire remote lock. Another client is syncing with $REMOTE or lock file couldn't be created. Exiting."
       release_lock
       exit 3
     else
-      ((tries++))
-      sleep 10
+      sleep 5
       $REMOTE_RUNNER "mkdir -p \"$REMOTE_TMP_DIR\"; cd \"$REMOTE_PATH\" && mkdir \"$LOCK_DIR\" 2>/dev/null"
     fi
   done
@@ -595,8 +599,11 @@ Available commands:
    help    Show this message.
 
 Options:
-   -p, --pretend    Don't really perform the sync or update the current
-                    state. Instead, show what would be synchronized.
+   -p, --pretend                     Don't really perform the sync or update the current
+                                     state. Instead, show what would be synchronized.
+   -w=WAIT_TIME, --wait=WAIT_TIME    Number of seconds to wait when trying to acquire a
+                                     lock on a remote host. This is useful if several
+                                     are syncing at the same time.
 
 Note: All commands (apart from help), must be run in the root of a
       new or existing bitpocket directory structure.
@@ -608,6 +615,7 @@ function parseargs() {
         case $1 in
             # Switches and configuration
             -p|--pretend)   OPTIONS+=('pretend');;
+            -w=*|--wait=*)   LOCK_ACQUIRE_TIMEOUT="${1#*=}";;
             -h|--help|-*)   COMMANDS+=('help');;
             # Arguments (commands)
             init)           if [[ $# < 2 ]]; then

--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -502,13 +502,19 @@ function release_lock {
 }
 
 function acquire_remote_lock {
+  tries=0
   $REMOTE_RUNNER "mkdir -p \"$REMOTE_TMP_DIR\"; cd \"$REMOTE_PATH\" && mkdir \"$LOCK_DIR\" 2>/dev/null"
-
-  if [[ $? != 0 ]]; then
-    echo "Couldn't acquire remote lock. Another client is syncing with $REMOTE or lock file couldn't be created. Exiting."
-    release_lock
-    exit 3
-  fi
+  while [[ $? != 0 ]]; do
+    if [ $tries -gt 20 ]; then
+      echo "Couldn't acquire remote lock. Another client is syncing with $REMOTE or lock file couldn't be created. Exiting."
+      release_lock
+      exit 3
+    else
+      ((tries++))
+      sleep 10
+      $REMOTE_RUNNER "mkdir -p \"$REMOTE_TMP_DIR\"; cd \"$REMOTE_PATH\" && mkdir \"$LOCK_DIR\" 2>/dev/null"
+    fi
+  done
 }
 
 function release_remote_lock {
@@ -571,7 +577,7 @@ function list {
 }
 
 function usage {
-  cat <<EOF  
+  cat <<EOF
 usage:  bitpocket { init [<REMOTE_HOST>] <REMOTE_PATH>
                   | sync | help | pack | log | cron | list }
 


### PR DESCRIPTION
When they are several clients for a same master with automatic cron sync, sync can fail systematically on some clients if the cron jobs are set at the same time. Rather the trying to fit all the clients in different time slots, we can try several time to acquire a lock until a certain time has passed or the lock is acquired.